### PR TITLE
Fix troubleshooting guide link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report--non-formatter-.md
+++ b/.github/ISSUE_TEMPLATE/bug-report--non-formatter-.md
@@ -8,7 +8,7 @@ labels: bug
 assignees: mark-wiemer
 ---
 
-For troubleshooting assistance, refer to the [troubleshooting guide](https://github.com/mark-wiemer/docs/Troubleshooting.md)
+For troubleshooting assistance, refer to the [troubleshooting guide](https://github.com/mark-wiemer/ahkpp/blob/main/docs/Troubleshooting.md)
 
 ## Description
 


### PR DESCRIPTION
The old one is a dead link



Changes proposed in this pull request:

-   Fixed link to point to correct location of troubleshooting docs

---

Replace "ISSUE" and "CHANGE" above with your values.

Do not edit below:

Notifying @mark-wiemer
