### PR TITLE
6.5.0 - 2025-02-23 💞

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.5.0 - unreleased 💞
+## 6.5.0 - 2025-02-23 💞
 
 ### Debugger
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@
 
 ### IntelliSense
 
--   Add detailed `__New` docs for `InputHook` and basic `__New` docs for all `Object` descendants that didn't have it([#586](https://github.com/mark-wiemer/ahkpp/issues/586))
+-   Add detailed `__New` docs for `InputHook` and basic `__New` docs for all `Object` descendants that didn't have it ([Issue #586](https://github.com/mark-wiemer/ahkpp/issues/586))
 
 ## 6.4.3 - 2025-01-18 🎆
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ Unless otherwise specified, commit messages don't matter.
 1. Commit the changes.
 1. Open a PR. For style, the title of the PR should be e.g. `1.2.3 - 2020-12-31 ❄️`. The PR description should contain the changelog entry, including the heading for this version.
 1. Fix any remaining issues with the PR.
-1. Merge the PR. Commit message should be the changelog heading, e.g. `1.2.3 - 2020-12-31 ❄️ (#456)`
+1. Merge the PR. Commit message should be the changelog heading + PR number, e.g. `1.2.3 - 2020-12-31 ❄️ (#456)`
 1. `git checkout main && git pull && npm run package`
 1. Install the new version:
     1. Select the newly-created `.vsix` file.

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,6 +33,7 @@ Unless otherwise specified, commit messages don't matter.
 1. Run `npm i` to update `package-lock.json`
 1. Commit the changes.
 1. Open a PR. For consistency, the title of the PR should be e.g. `1.2.3 - 2020-12-31 ❄️`. The PR description should contain the changelog entry, including the heading for this version.
+1. Go to `https://github.com/mark-wiemer/ahkpp/compare` to review all changes since last release.
 1. Fix any remaining issues with the PR.
 1. Merge the PR. Commit message should be the changelog heading + PR number, e.g. `1.2.3 - 2020-12-31 ❄️ (#456)`
 1. `git checkout main && git pull && npm run package`

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,7 +32,7 @@ Unless otherwise specified, commit messages don't matter.
 1. Bump the version in `package.json`
 1. Run `npm i` to update `package-lock.json`
 1. Commit the changes.
-1. Open a PR. For style, the title of the PR should be e.g. `1.2.3 - 2020-12-31 ❄️`. The PR description should contain the changelog entry, including the heading for this version.
+1. Open a PR. For consistency, the title of the PR should be e.g. `1.2.3 - 2020-12-31 ❄️`. The PR description should contain the changelog entry, including the heading for this version.
 1. Fix any remaining issues with the PR.
 1. Merge the PR. Commit message should be the changelog heading + PR number, e.g. `1.2.3 - 2020-12-31 ❄️ (#456)`
 1. `git checkout main && git pull && npm run package`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "6.4.3",
+    "version": "6.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "6.4.3",
+            "version": "6.5.0",
             "license": "See license.md",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AHK++ (AutoHotkey Plus Plus)",
-    "version": "6.4.3",
+    "version": "6.5.0",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more!",
     "categories": [
         "Debuggers",


### PR DESCRIPTION
## 6.5.0 - 2025-02-23 💞

### Debugger

-   Add [docs/debugging.md](./docs/debugging.md) and [docs/\_welcome.md](./docs/_welcome.md)
-   Fix `.vscode/launch.json` support for AHK v1 ([Issue #603](https://github.com/mark-wiemer/ahkpp/issues/603))
-   Add `.vscode/launch.json` support for AHK v2 ([PR #606](https://github.com/mark-wiemer/ahkpp/issues/603))
-   Change "AutoHotkey execute bin not found: ..." to "AutoHotkey interpreter not found" with a preceding message showing the interpreter path. ([PR #606](https://github.com/mark-wiemer/ahkpp/issues/603))
-   Remove the `runtime` argument from `launch.json` for both AHK v1 and AHK v2 due to issues with cross-version debugging ([PR #606](https://github.com/mark-wiemer/ahkpp/issues/603))
    -   We are not considering this a breaking change as this behavior didn't work before. If you'd like to use different AHK interpreters across different workspaces, use IDE workspace settings. If you'd like to use different AHK interpreters within a single workspace, please [open a discussion](https://github.com/mark-wiemer/ahkpp/discussions/new/choose) and we'll be happy to help.

### IntelliSense

-   Add detailed `__New` docs for `InputHook` and basic `__New` docs for all `Object` descendants that didn't have it ([Issue #586](https://github.com/mark-wiemer/ahkpp/issues/586))