### PR TITLE
6.6.0 - 2025-03-21 🎩

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -58,7 +58,7 @@
 
 ### New features
 
--   Hovering over a filename in an `#include` directive now provides a link to that document in your IDE
+-   Hovering over a filename in a `#include` directive now provides a link to that document in your IDE
     -   If the file doesn't exist, the underline doesn't appear
     -   Does not work for `#include <lib>` syntax yet.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,14 +1,14 @@
 # Changelog
 
-## 6.5.1 - unreleased
+## 6.6.0 - 2025-03-21 🎩
 
 -   Improve extension performance when loading AHK v1 scripts ([PR #615](https://github.com/mark-wiemer/ahkpp/pull/615))
--   Change `Method` to `Function` in document symbols and internal references. This changes the document outline slightly, but should not change most theme icons and is more correct. ([PR #620](https://github.com/mark-wiemer/ahkpp/pull/620)).
+-   Change `Method` to `Function` in document symbols and internal references. This changes the document outline slightly, but should not change most theme icons and is more correct. ([PR #620](https://github.com/mark-wiemer/ahkpp/pull/620))
 
 ### v1-exclusive changes
 
 -   Have scripts referenced by `#include` bypass the `exclude` setting ([PR #623](https://github.com/mark-wiemer/ahkpp/pull/623))
--   Add experimental `funcDefSearch` setting that improves function definition resolution ([PR #623](https://github.com/mark-wiemer/ahkpp/pull/623))
+-   Add experimental `funcDefSearch` setting that improves function definition resolution. For known issues, see [`settings.md`](./docs/settings.md). ([PR #623](https://github.com/mark-wiemer/ahkpp/pull/623))
 
 ## 6.5.0 - 2025-02-23 💞
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -12,3 +12,4 @@ Links are to the AHK v2 definition of the related term. Links are only provided 
 | [Function](https://www.autohotkey.com/docs/v2/Concepts.htm#functions) | an AHK function, usually in the context of "function ref" or "function definition" |
 | [Method](https://www.autohotkey.com/docs/v2/Concepts.htm#methods)     | an AHK function attached to an object                                              |
 | Reference                                                             | a function call or definition                                                      |
+| Directive                                                             | e.g. "a `#include` directive", pronounced "a hashtag-include directive"            |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -122,6 +122,10 @@ Known issues with this feature:
 
 -   It does not account for `#include <dir>` directives which change the base path of inclusion ([#628](https://github.com/mark-wiemer/ahkpp/issues/628))
 
+Related issues:
+
+-   Functions declared in user or standard libraries are not found unless they're located in the workspace or referenced by `#include path/to/libFile.ahk`. `#include <lib>` is not recognized by AHK++. ([#629](https://github.com/mark-wiemer/ahkpp/issues/629))
+
 ## Other IDE settings
 
 It's always good to explore your IDE! There are a million settings to learn,

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -120,8 +120,7 @@ This setting fixes [issue #205](https://github.com/mark-wiemer/ahkpp/issues/205)
 
 Known issues with this feature:
 
--   It does not account for `#include <dir>` directives which change the base path of inclusion
--   If a file is renamed, links to functions declared in that file may fail. Restarting the extension should solve this issue.
+-   It does not account for `#include <dir>` directives which change the base path of inclusion ([#628](https://github.com/mark-wiemer/ahkpp/issues/628))
 
 ## Other IDE settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,9 +1486,9 @@
             }
         },
         "node_modules/@vscode/vsce": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.2.2.tgz",
-            "integrity": "sha512-4TqdUq/yKlQTHcQMk/DamR632bq/+IJDomSbexOMee/UAYWqYm0XHWA6scGslsCpzY+sCWEhhl0nqdOB0XW1kw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.3.0.tgz",
+            "integrity": "sha512-HA/pUyvh/TQWkc4wG7AudPIWUvsR8i4jiWZZgM/a69ncPi9Nm5FDogf/wVEk4EWJs4/UdxU7J6X18dfAwfPbxA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "6.5.0",
+    "version": "6.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "6.5.0",
+            "version": "6.6.0",
             "license": "See license.md",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AHK++ (AutoHotkey Plus Plus)",
-    "version": "6.5.1-dev",
+    "version": "6.6.0",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more!",
     "categories": [
         "Debuggers",


### PR DESCRIPTION
## 6.6.0 - 2025-03-21 🎩

-   Improve extension performance when loading AHK v1 scripts ([PR #615](https://github.com/mark-wiemer/ahkpp/pull/615))
-   Change `Method` to `Function` in document symbols and internal references. This changes the document outline slightly, but should not change most theme icons and is more correct. ([PR #620](https://github.com/mark-wiemer/ahkpp/pull/620))

### v1-exclusive changes

-   Have scripts referenced by `#include` bypass the `exclude` setting ([PR #623](https://github.com/mark-wiemer/ahkpp/pull/623))
-   Add experimental `funcDefSearch` setting that improves function definition resolution. For known issues, see [`settings.md`](./docs/settings.md). ([PR #623](https://github.com/mark-wiemer/ahkpp/pull/623))