### PR TITLE
6.7.0 - 2025-04-01 🤡

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.7.0 - unreleased
+## 6.7.0 - 2025-04-01 🤡
 
 -   Add `AHK++ > General > logLevel` for logs in output channels ([#625](https://github.com/mark-wiemer/ahkpp/issues/625), [#635](https://github.com/mark-wiemer/ahkpp/issues/635))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "6.7.0-dev",
+    "version": "6.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "6.7.0-dev",
+            "version": "6.7.0",
             "license": "See license.md",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AHK++ (AutoHotkey Plus Plus)",
-    "version": "6.7.0-dev",
+    "version": "6.7.0",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more!",
     "categories": [
         "Debuggers",


### PR DESCRIPTION
## 6.7.0 - 2025-04-01 🤡

-   Add `AHK++ > General > logLevel` for logs in output channels ([#625](https://github.com/mark-wiemer/ahkpp/issues/625), [#635](https://github.com/mark-wiemer/ahkpp/issues/635))