### PR TITLE
Remove "Invalid setting" log if `logLevel` setting was not found

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## 6.7.1 - unreleased
 
 -   Make "Configuration changed" log debug-level instead of info-level ([#625 (comment)](https://github.com/mark-wiemer/ahkpp/issues/625#issuecomment-2772599772))
+-   Remove "Invalid setting" log if `logLevel` setting was not found ([#644](https://github.com/mark-wiemer/ahkpp/issues/644))
 
 ## 6.7.0 - 2025-04-01 🤡
 

--- a/src/common/log.ts
+++ b/src/common/log.ts
@@ -46,16 +46,10 @@ export const critical = (value: Error | string) =>
 
 /**
  * Logs message if provided log level is valid for configured log level.
- * Logs warning if configured log level is invalid.
  */
 const log = (value: Error | string, thisLevel: LogLevel) => {
     const configLevel: LogLevel | undefined = logLevelRecord[configLevelStr];
-    if (configLevel === undefined) {
-        logInner(`Invalid setting AHK++.general.logLevel: "${configLevelStr}"`);
-        getOutputChannel().show(false);
-        return;
-    }
-    if (configLevel === LogLevel.None) {
+    if (configLevel === undefined || configLevel === LogLevel.None) {
         return;
     }
     if (thisLevel >= configLevel) {


### PR DESCRIPTION
Closes #644.

Changes proposed in this pull request:

-   Remove "Invalid setting" log if `logLevel` setting was not found