### PR TITLE
Improve resolveIncludedPaths logic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 -   Make "Configuration changed" log debug-level instead of info-level ([#625 (comment)](https://github.com/mark-wiemer/ahkpp/issues/625#issuecomment-2772599772))
 -   Remove "Invalid setting" log if `logLevel` setting was not found ([#644](https://github.com/mark-wiemer/ahkpp/issues/644))
--   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641))
+-   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641), [#646](https://github.com/mark-wiemer/ahkpp/issues/646))
     -   Logic to detect these files has improved but still has at least one known issue ([#628](https://github.com/mark-wiemer/ahkpp/issues/628))
     -   When a file isn't found, the log is now `debug` level instead of `warn` level to reduce noise
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 -   Make "Configuration changed" log debug-level instead of info-level ([#625 (comment)](https://github.com/mark-wiemer/ahkpp/issues/625#issuecomment-2772599772))
 -   Remove "Invalid setting" log if `logLevel` setting was not found ([#644](https://github.com/mark-wiemer/ahkpp/issues/644))
+-   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641))
+    -   Logic to detect these files has improved but still has at least one known issue ([#628](https://github.com/mark-wiemer/ahkpp/issues/628))
+    -   When a file isn't found, the log is now `debug` level instead of `warn` level to reduce noise
 
 ## 6.7.0 - 2025-04-01 🤡
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,8 @@
 
 -   Make "Configuration changed" log debug-level instead of info-level ([#625 (comment)](https://github.com/mark-wiemer/ahkpp/issues/625#issuecomment-2772599772))
 -   Remove "Invalid setting" log if `logLevel` setting was not found ([#644](https://github.com/mark-wiemer/ahkpp/issues/644))
--   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641), [#646](https://github.com/mark-wiemer/ahkpp/issues/646))
-    -   Logic to detect these files has improved but still has at least one known issue ([#628](https://github.com/mark-wiemer/ahkpp/issues/628))
+-   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641), [#646](https://github.com/mark-wiemer/ahkpp/issues/646), and [#649](https://github.com/mark-wiemer/ahkpp/issues/649))
+    -   Logic to detect these files has improved but still has at least one known issue: [#628](https://github.com/mark-wiemer/ahkpp/issues/628)
     -   When a file isn't found, the log is now `debug` level instead of `warn` level to reduce noise
 
 ## 6.7.0 - 2025-04-01 🤡

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -49,6 +49,22 @@ suite(resolveIncludedPath.name, () => {
     ][] = [
         ['relative file', ['/c:/main.ahk', 'a.ahk'], 'c:\\a.ahk'],
         ['absolute file', ['/c:/users/main.ahk', 'd:/b.ahk'], 'd:\\b.ahk'],
+        [
+            'A_ScriptDir',
+            ['/c:/users/main.ahk', '%A_ScriptDir%/AutoXYWH.ahk'],
+            'c:\\users\\AutoXYWH.ahk',
+        ],
+        [
+            'A_WorkingDir',
+            ['/c:/users/main.ahk', '%A_WorkingDir%/AutoXYWH.ahk'],
+            'c:\\users\\AutoXYWH.ahk',
+        ],
+        [
+            'A_LineFile',
+            ['/c:/users/main.ahk', '%A_LineFile%/../other.ahk'],
+            // Starting with a forward slash still works :)
+            '\\c:\\users\\other.ahk',
+        ],
         ['with single dot', ['/c:/main.ahk', './c.ahk'], 'c:\\c.ahk'],
         ['with double dot', ['/c:/users/main.ahk', '../d.ahk'], 'c:\\d.ahk'],
     ];

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -71,8 +71,8 @@ export const resolveIncludedPath = (
         basePath,
         parentGoodPath,
     );
-    const absolutePath = isAbsolute(includedPath)
-        ? normalize(includedPath)
+    const absolutePath = isAbsolute(normalizedPath)
+        ? normalizedPath
         : join(parentGoodPath, normalizedPath);
     return absolutePath;
 };

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -4,7 +4,7 @@ import { CodeUtil } from '../common/codeUtil';
 import { Script, FuncDef, FuncRef, Label, Block, Variable } from './model';
 import { scriptCache, pathsToBuild } from './parser.utils';
 import { resolveIncludedPath } from '../common/utils';
-import { debug, warn } from '../common/log';
+import { debug } from '../common/log';
 
 const startBlockComment = / *\/\*/;
 // todo does endBlockComment work on lines like `; */` ?
@@ -39,8 +39,10 @@ const buildPaths = async (
             debug(`buildPaths opened` + document);
             await Parser.buildScript(document, options);
         } catch (e) {
-            warn(`${funcName} error building ${path}`);
-            warn(e);
+            // Issues are common here, this is still experimental
+            // https://github.com/mark-wiemer/ahkpp/issues/628
+            debug(`${funcName} error building ${path}`);
+            debug(e);
         }
     }
 };
@@ -177,8 +179,8 @@ export class Parser {
         scriptCache.set(docPath, script);
 
         // we can build included paths at the end because we don't store
-        // definition locations of all function calls
-        // in the cache, we search and find them as needed based on user action
+        // definition locations of all function calls in the cache,
+        // we search and find them as needed based on user action
         debug(`Building included paths:`);
         debug('\t' + (includedPaths.join('\n\t') || '(none)'));
         await buildPaths(includedPaths, { usingCache: true });


### PR DESCRIPTION
- Closes #641
- Closes #646
- Closes #649

Changes proposed in this pull request:

-   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641), [#646](https://github.com/mark-wiemer/ahkpp/issues/646), and [#649](https://github.com/mark-wiemer/ahkpp/issues/649))
    -   Logic to detect these files has improved but still has at least one known issue: [#628](https://github.com/mark-wiemer/ahkpp/issues/628)
    -   When a file isn't found, the log is now `debug` level instead of `warn` level to reduce noise
