### PR TITLE
6.7.1 - 2025-05-16 🎓

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.7.1 - unreleased
+## 6.7.1 - 2025-05-16 🎓
 
 -   Make "Configuration changed" log debug-level instead of info-level ([#625 (comment)](https://github.com/mark-wiemer/ahkpp/issues/625#issuecomment-2772599772))
 -   Remove "Invalid setting" log if `logLevel` setting was not found ([#644](https://github.com/mark-wiemer/ahkpp/issues/644))

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 -   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641), [#646](https://github.com/mark-wiemer/ahkpp/issues/646), [#649](https://github.com/mark-wiemer/ahkpp/issues/649), and [#657](https://github.com/mark-wiemer/ahkpp/issues/646))
     -   Logic to detect these files has improved but still has at least one known issue: [#628](https://github.com/mark-wiemer/ahkpp/issues/628)
     -   When a file isn't found, the log is now `debug` level instead of `warn` level to reduce noise
+-   Improve AHK v1 snippet for `CoordMode` ([PR #651](https://github.com/mark-wiemer/ahkpp/pull/651))
 
 ## 6.7.0 - 2025-04-01 🤡
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 -   Make "Configuration changed" log debug-level instead of info-level ([#625 (comment)](https://github.com/mark-wiemer/ahkpp/issues/625#issuecomment-2772599772))
 -   Remove "Invalid setting" log if `logLevel` setting was not found ([#644](https://github.com/mark-wiemer/ahkpp/issues/644))
--   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641), [#646](https://github.com/mark-wiemer/ahkpp/issues/646), and [#649](https://github.com/mark-wiemer/ahkpp/issues/649))
+-   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641), [#646](https://github.com/mark-wiemer/ahkpp/issues/646), [#649](https://github.com/mark-wiemer/ahkpp/issues/649), and [#657](https://github.com/mark-wiemer/ahkpp/issues/646))
     -   Logic to detect these files has improved but still has at least one known issue: [#628](https://github.com/mark-wiemer/ahkpp/issues/628)
     -   When a file isn't found, the log is now `debug` level instead of `warn` level to reduce noise
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "6.7.0",
+    "version": "6.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "6.7.0",
+            "version": "6.7.1",
             "license": "See license.md",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AHK++ (AutoHotkey Plus Plus)",
-    "version": "6.7.0",
+    "version": "6.7.1",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more!",
     "categories": [
         "Debuggers",


### PR DESCRIPTION
## 6.7.1 - 2025-05-16 🎓

-   Make "Configuration changed" log debug-level instead of info-level ([#625 (comment)](https://github.com/mark-wiemer/ahkpp/issues/625#issuecomment-2772599772))
-   Remove "Invalid setting" log if `logLevel` setting was not found ([#644](https://github.com/mark-wiemer/ahkpp/issues/644))
-   Fix excessive logs when `#include` files aren't found by AHK++ ([#641](https://github.com/mark-wiemer/ahkpp/issues/641), [#646](https://github.com/mark-wiemer/ahkpp/issues/646), [#649](https://github.com/mark-wiemer/ahkpp/issues/649), and [#657](https://github.com/mark-wiemer/ahkpp/issues/646))
    -   Logic to detect these files has improved but still has at least one known issue: [#628](https://github.com/mark-wiemer/ahkpp/issues/628)
    -   When a file isn't found, the log is now `debug` level instead of `warn` level to reduce noise