### PR TITLE
Use AHKPP_DEBUG to reduce conflicts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 -   Add docs for `WinGetAlwaysOnTop` in AHK v2
 -   Fix typo in docs for "or" operator ("bet" to "be")
 -   Update internal dependencies
+-   Use `AHKPP_DEBUG` instead of `DEBUG` global variable ([issue #701](https://github.com/mark-wiemer/ahkpp/issues/701))
 
 ## 6.7.3 - 2026-01-13 🤫
 


### PR DESCRIPTION
Fixes #701

Previously, the extension used the DEBUG global, which is more likely to be set by other extensions.