### PR TITLE
6.7.4 - 2026-08-07 👋

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 -   Add docs for `WinGetAlwaysOnTop` in AHK v2
 -   Use `AHKPP_DEBUG` instead of `DEBUG` global variable ([#701](https://github.com/mark-wiemer/ahkpp/issues/701))
--   Fix "Open AutoHotkey Help" for non-English users ([[#727](https://github.com/mark-wiemer/ahkpp/issues/727)])
+-   Fix "Open AutoHotkey Help" for non-English users ([#727](https://github.com/mark-wiemer/ahkpp/issues/727))
 -   Fix typo in docs for "or" operator ("bet" to "be")
 -   Update internal dependencies
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 6.7.4 - 2026-08-07 👋
 
 -   Add docs for `WinGetAlwaysOnTop` in AHK v2
 -   Use `AHKPP_DEBUG` instead of `DEBUG` global variable ([#701](https://github.com/mark-wiemer/ahkpp/issues/701))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-autohotkey-plus-plus",
-    "version": "6.7.3",
+    "version": "6.7.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-autohotkey-plus-plus",
-            "version": "6.7.3",
+            "version": "6.7.4",
             "license": "See license.md",
             "dependencies": {
                 "@vscode/debugadapter": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-autohotkey-plus-plus",
     "displayName": "AHK++ (AutoHotkey Plus Plus)",
-    "version": "6.7.3",
+    "version": "6.7.4",
     "description": "AutoHotkey v1 and v2 language support for Visual Studio Code: IntelliSense, debugging, formatting, and more!",
     "categories": [
         "Debuggers",


### PR DESCRIPTION
## 6.7.4 - 2026-08-07 👋

-   Add docs for `WinGetAlwaysOnTop` in AHK v2
-   Use `AHKPP_DEBUG` instead of `DEBUG` global variable ([#701](https://github.com/mark-wiemer/ahkpp/issues/701))
-   Fix "Open AutoHotkey Help" for non-English users ([#727](https://github.com/mark-wiemer/ahkpp/issues/727))
-   Fix typo in docs for "or" operator ("bet" to "be")
-   Update internal dependencies