### PR TITLE
Fix word-based suggestions support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   Fix setting interpreter path ([#571](https://github.com/mark-wiemer/ahkpp/issues/571))
+-   Fix word-based suggestions support ([#250](https://github.com/mark-wiemer/ahkpp/issues/250))
 -   Add support for Windows Store edition ([#496](https://github.com/mark-wiemer/ahkpp/issues/496))
 
 ## 6.7.4 - 2026-08-07 👋

--- a/e2e/main.ahk1
+++ b/e2e/main.ahk1
@@ -3,3 +3,8 @@
 SendMode, Input
 SetBatchLines, -1
 SetWorkingDir, %A_ScriptDir%
+
+; To ensure word-based suggestions don't kick in,
+; we add a similarly-named function
+MyExclusionControl() {
+}

--- a/e2e/main.ahk2
+++ b/e2e/main.ahk2
@@ -1,7 +1,5 @@
 #Requires AutoHotkey v2.0
 
 ; Exclude pattern: excluded.ahk
-;* Should not suggest the excluded func in completion
-; Do not write func by name here,
-; as it would be included in word-based suggestions
+;* Should suggest "MyExcludedFunc" in completion based on exclude pattern
 MyExclu

--- a/e2e/main.ahk2
+++ b/e2e/main.ahk2
@@ -1,5 +1,7 @@
 #Requires AutoHotkey v2.0
 
 ; Exclude pattern: excluded.ahk
-;* Should not suggest "MyExcludedFunc" in completion
+;* Should not suggest the excluded func in completion
+; Do not write func by name here,
+; as it would be included in word-based suggestions
 MyExclu

--- a/src/providers/completionProvider.e2e.ts
+++ b/src/providers/completionProvider.e2e.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
 import { provideCompletionItemsInner } from './completionProvider';
+import { getCompletionSuggestionLabels, showDocument } from '../test/utils';
 
 // TODO outer
 // parsing vs no parsing
@@ -349,4 +350,24 @@ suite('provideCompletionItemsInner', () => {
             assert.deepEqual(provideCompletionItemsInner(...args), expected),
         ),
     );
+});
+
+suite('CompletionProvider', () => {
+    test('keeps word-based suggestions available when no IntelliSense item matches', async () => {
+        const word = 'wordBasedFallbackUnique';
+        const prefix = word.slice(0, -6);
+        const document = await vscode.workspace.openTextDocument({
+            content: `; ${word}\n${prefix}`,
+            language: 'ahk',
+        });
+        const editor = await showDocument(document);
+        editor.selection = new vscode.Selection(
+            new vscode.Position(1, prefix.length),
+            new vscode.Position(1, prefix.length),
+        );
+
+        const labels = await getCompletionSuggestionLabels(editor);
+
+        assert.ok(labels.includes(word));
+    });
 });

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { Parser } from '../parser/parser';
 import { SnippetString } from 'vscode';
 import { FuncDef } from '../parser/model';
+import { hasMatchingCompletionItem } from './completionProvider.utils';
 
 type SimpleFuncDef = Pick<
     FuncDef,
@@ -105,11 +106,14 @@ export const provideCompletionItemsInner = (
         .concat(variables.map(completionItemForVariable));
 
 export class CompletionProvider implements vscode.CompletionItemProvider {
+    /**
+     * Returns completion items, or undefined if no items match current word.
+     */
     // TODO add tests
     public async provideCompletionItems(
         document: vscode.TextDocument,
         position: vscode.Position,
-    ): Promise<vscode.CompletionItem[]> {
+    ): Promise<vscode.CompletionItem[] | undefined> {
         // If the cursor is just after a dot, don't suggest anything.
         // Default suggestions will still apply.
         const preChar = document.getText(
@@ -123,7 +127,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
         // Suggest all variables in the current file
         const funcDefs = await Parser.getAllFuncDefs();
         const script = await Parser.buildScript(document, { usingCache: true });
-        return provideCompletionItemsInner(
+        const completionItems = provideCompletionItemsInner(
             funcDefs.map((m) => ({
                 ...m,
                 variables: m.variables.map((v) => v.name),
@@ -132,5 +136,15 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
             position.line,
             script.variables.map((v) => v.name),
         );
+        const wordRange = document.getWordRangeAtPosition(position);
+        const prefix = wordRange
+            ? document.getText(new vscode.Range(wordRange.start, position))
+            : '';
+        const completionLabels = completionItems.map((item) =>
+            typeof item.label === 'string' ? item.label : item.label.label,
+        );
+        return hasMatchingCompletionItem(completionLabels, prefix)
+            ? completionItems
+            : undefined;
     }
 }

--- a/src/providers/completionProvider.utils.test.ts
+++ b/src/providers/completionProvider.utils.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+import { suite, test } from 'mocha';
+import { hasMatchingCompletionItem } from './completionProvider.utils';
+
+suite('hasMatchingCompletionItem', () => {
+    const completionLabels = ['alpha', 'beta'];
+
+    test('matches before a word is started', () => {
+        assert.equal(hasMatchingCompletionItem(completionLabels, ''), true);
+    });
+
+    test('matches without considering case', () => {
+        assert.equal(hasMatchingCompletionItem(completionLabels, 'AL'), true);
+    });
+
+    test('does not match a missing prefix', () => {
+        assert.equal(
+            hasMatchingCompletionItem(completionLabels, 'word'),
+            false,
+        );
+    });
+});

--- a/src/providers/completionProvider.utils.ts
+++ b/src/providers/completionProvider.utils.ts
@@ -1,0 +1,8 @@
+export const hasMatchingCompletionItem = (
+    completionLabels: string[],
+    prefix: string,
+): boolean =>
+    !prefix ||
+    completionLabels.some((label) =>
+        label.toLocaleLowerCase().startsWith(prefix.toLocaleLowerCase()),
+    );

--- a/src/test/config.e2e.ts
+++ b/src/test/config.e2e.ts
@@ -96,7 +96,11 @@ suite('exclude', () => {
 
             const labels = await getCompletionSuggestionLabels(editor);
 
-            assert.strictEqual(labels.includes(funcName), expected);
+            assert.strictEqual(
+                labels.includes(funcName),
+                expected,
+                labels.toString(),
+            );
         });
     });
 });


### PR DESCRIPTION
Fixes #250

We were previously returning irrelevant suggestions, blocking VS Code from providing the low-priority word-based suggestions. This PR checks if any suggestions are relevant based on a case-insensitive match with current word and returns undefined (not empty array) to clarify that AHK++ has nothing to add here. This allows VS Code to move to the next provider.

[provideCompletionItems - VS Code API](https://code.visualstudio.com/api/references/vscode-api#CompletionItemProvider.provideCompletionItems)