### PR TITLE
Update CI to actions 7 again, remove Node 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,14 @@ jobs:
   build:
     strategy:
       matrix:
-        # AHK is built for Windows only, so we only build on Windows
-        os: [windows-latest]
-        node-version: [22.x, 26.x]
-    runs-on: ${{ matrix.os }}
+        node-version: [26.x]
+    # AHK is built for Windows only, so we only build on Windows
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
Should've updated setup-node to 7 last time, oops!

Node 22 is EOL as of April 2026.

