### PR TITLE
Clarify template snippet docs

### DIFF
--- a/docs/template-snippet.md
+++ b/docs/template-snippet.md
@@ -10,7 +10,7 @@ SetBatchLines, -1
 SetWorkingDir, %A_ScriptDir%
 ```
 
-AHK++ includes default templates for v1 and v2. They are extension-owned snippets, so VS Code does not show or allow editing them through the Command Palette. To customize the template snippet, create a user snippet and configure AHK++ to use it:
+AHK++ includes two default templates: one for each AHK version. The default templates are provided by extension-owned snippets, so VS Code does not show or allow editing them through the Command Palette. To customize a template snippet, create a user snippet and configure AHK++ to use it:
 
 1. In VS Code, open the command palette (F1) and go to "Snippets: Configure Snippets".
 

--- a/docs/template-snippet.md
+++ b/docs/template-snippet.md
@@ -10,16 +10,16 @@ SetBatchLines, -1
 SetWorkingDir, %A_ScriptDir%
 ```
 
-You can customize the template snippet to fit your needs:
+AHK++ includes default templates for v1 and v2. They are extension-owned snippets, so VS Code does not show or allow editing them through the Command Palette. To customize the template snippet, create a user snippet and configure AHK++ to use it:
 
-1. In VS Code, open the command palette (F1) and go to "Snippets: Configure User Snippets".
+1. In VS Code, open the command palette (F1) and go to "Snippets: Configure Snippets".
 
 1. Choose a global snippets file or create a new one.
 
 1. Create a new snippet with a unique name, for example:
 
     ```json
-    "CustomAhkTemplate": {
+    "MyAhkTemplate": {
         "body": [
             "; My new script with no directives",
             "; Here is a second comment line",
@@ -28,7 +28,7 @@ You can customize the template snippet to fit your needs:
     }
     ```
 
-1. Update your VS Code settings for AHK > File > "Template snippet name" to the name of your snippet (`CustomAhkTemplate`)
+1. Update your VS Code settings: Both `AHK++.v1.file` and `AHK++.v2.file` have a `templateSnippetName` entry. Update that to the name of your snippet (`MyAhkTemplate`)
 
 To test, just create a new file! If you have any issues, please [open a discussion](https://github.com/mark-wiemer/ahkpp/discussions).
 


### PR DESCRIPTION
Closes #498

There was some confusion about whether the extension-bundled snippets files were editable. A user and I both stated they were supposed to be editable, but they are not supposed to be editable.

This docs update clarifies how to customize the template snippet without editing the extension-bundled snippets files.